### PR TITLE
Fix - Alias Definition for 'src' Directory

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,22 +1,22 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import CompanyRegistration from '@/views/CompanyRegistration.vue'
-import EmployeesList from '../views/EmployeesList.vue'
-import Login from '../views/LoginForm.vue'
-import BenefitList from '@/components/BenefitList.vue' 
+import EmployeesList from '@/views/EmployeesList.vue'
+import Login from '@/views/LoginForm.vue'
+import BenefitList from '@/components/BenefitList.vue'
 import Benefit from '@/components/BenefitView.vue'
 import BenefitCreate from '@/components/BenefitCreate.vue'
 import SelectChangeBenefit from '@/components/SelectChangeBenefit.vue'
 
 const routes =
-[
-    { path: '/login', name: 'LoginForm', component: Login },
-    { path: '/company-registration', name: 'CompanyRegistration', component: CompanyRegistration},
-    { path: '/employees-list', name: 'EmployeesList', component: EmployeesList },
-    { path: '/benefits', name: 'Benefits', component: BenefitList },
-    { path: '/benefit/:id', name: 'Benefit', component: Benefit, props: true },
-    { path: '/benefit/create', name: 'CreateBenefit', component: BenefitCreate },
-    { path: '/select-change-benefit', name: 'SelectChangeBenefit', component: SelectChangeBenefit },
-]
+    [
+        { path: '/login', name: 'LoginForm', component: Login },
+        { path: '/company-registration', name: 'CompanyRegistration', component: CompanyRegistration },
+        { path: '/employees-list', name: 'EmployeesList', component: EmployeesList },
+        { path: '/benefits', name: 'Benefits', component: BenefitList },
+        { path: '/benefit/:id', name: 'Benefit', component: Benefit, props: true },
+        { path: '/benefit/create', name: 'CreateBenefit', component: BenefitCreate },
+        { path: '/select-change-benefit', name: 'SelectChangeBenefit', component: SelectChangeBenefit },
+    ]
 
 const router = createRouter({
     history: createWebHistory(),

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -1,4 +1,13 @@
 const { defineConfig } = require('@vue/cli-service')
+const path = require('path')
+
 module.exports = defineConfig({
-  transpileDependencies: true
+  transpileDependencies: true,
+  configureWebpack: {
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, 'src')
+      }
+    }
+  }
 })


### PR DESCRIPTION
# Description
This pull request defines the `@` alias for the `src` directory in `vue.config.js` and updates the import paths for the router in `index.js` to utilize this alias. This is a fix for the issue where the router could not resolve the components using the `@` alias.

# Main Changes
- Defined the `@` alias in `frontend/vue.config.js` to point to the `src` directory.
- Updated the import statements in `frontend/src/router/index.js` to use the `@` alias instead of relative paths.

# Motivation and Context
This change was made to improve code readability and maintainability by using a consistent alias for imports. It also addresses the issue of module resolution errors that occurred when the router could not resolve components using the `@` alias.

# How to Test
Clear instructions for testing the changes locally:
1. Clone this branch.
2. Run `npm install` to ensure all dependencies are up to date.
3. Start the application with `npm run serve`.
4. Navigate to the application and verify that all routes load correctly without any module resolution errors.