### PR TITLE
chore: add unit testing in deductions

### DIFF
--- a/TestPayrollSystem/CcssDeductionStrategyTest.cs
+++ b/TestPayrollSystem/CcssDeductionStrategyTest.cs
@@ -1,0 +1,33 @@
+﻿using backend.Domain.Strategies;
+using NUnit.Framework;
+
+namespace TestPayrollSystem
+{
+    [TestFixture]
+    public class CcssDeductionStrategyTest
+    {
+        private CcssDeductionStrategy _strategy;
+
+        [SetUp]
+        public void Setup()
+        {
+            _strategy = new CcssDeductionStrategy();
+        }
+
+        [Test]
+        public void CalculateDeduction_ProfessionalServices_ReturnsZero()
+        {
+            var result = _strategy.CalculateDeduction(1_000_000m, "Professional Services", "F");
+            Assert.AreEqual(0m, result);
+        }
+        [Test]
+        public void CalculateDeduction_AboveMinimumBase_UsesGrossSalary()
+        {
+            var gross = 1_000_000m;
+            var expected = Math.Round(gross * 0.0550m + gross * 0.0417m, 2);
+            var result = _strategy.CalculateDeduction(gross, "Permanent", "F");
+            Assert.AreEqual(expected, result);
+        }
+    }
+}
+

--- a/TestPayrollSystem/DeductionStrategyTest.cs
+++ b/TestPayrollSystem/DeductionStrategyTest.cs
@@ -1,0 +1,94 @@
+﻿using backend.Domain;
+using backend.Domain.Strategies;
+using NUnit.Framework;
+using System;
+
+namespace TestPayrollSystem
+{
+    [TestFixture]
+    public class DeductionStrategyTest
+    {
+        private BenefitDeductionStrategy _strategy;
+
+        [SetUp]
+        public void Setup()
+        {
+            _strategy = new BenefitDeductionStrategy();
+        }
+
+        [Test]
+        public void CalculateDeduction_BenefitIsNull_ReturnsZero()
+        {
+            var result = _strategy.CalculateDeduction(1000m, "FullTime", "M", null);
+            Assert.AreEqual(0m, result);
+        }
+
+        [Test]
+        public void CalculateDeduction_TypeIsFixedAmount_ReturnsFixedAmount()
+        {
+            var benefit = new Benefit
+            {
+                Type = "FixedAmount",
+                FixedAmount = 150
+            };
+
+            var result = _strategy.CalculateDeduction(2000m, "FullTime", "F", benefit);
+            Assert.AreEqual(150m, result);
+        }
+
+        [Test]
+        public void CalculateDeduction_TypeIsFixedAmount_NullAmount_ReturnsZero()
+        {
+            var benefit = new Benefit
+            {
+                Type = "FixedAmount",
+                FixedAmount = null
+            };
+
+            var result = _strategy.CalculateDeduction(2000m, "FullTime", "F", benefit);
+            Assert.AreEqual(0m, result);
+        }
+
+        [Test]
+        public void CalculateDeduction_TypeIsFixedPercentage_ReturnsCorrectPercentage()
+        {
+            var benefit = new Benefit
+            {
+                Type = "FixedPercentage",
+                FixedPercentage = 5 // 5%
+            };
+
+            var grossSalary = 1000m;
+            var expected = Math.Round(grossSalary * 0.05m, 2);
+
+            var result = _strategy.CalculateDeduction(grossSalary, "Contractor", "M", benefit);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void CalculateDeduction_TypeIsFixedPercentage_NullPercentage_ReturnsZero()
+        {
+            var benefit = new Benefit
+            {
+                Type = "FixedPercentage",
+                FixedPercentage = null
+            };
+
+            var result = _strategy.CalculateDeduction(2000m, "FullTime", "F", benefit);
+            Assert.AreEqual(0m, result);
+        }
+
+        [Test]
+        public void CalculateDeduction_UnknownType_ReturnsZero()
+        {
+            var benefit = new Benefit
+            {
+                Type = "OtherUnknownType"
+            };
+
+            var result = _strategy.CalculateDeduction(2000m, "FullTime", "M", benefit);
+            Assert.AreEqual(0m, result);
+        }
+    }
+}

--- a/TestPayrollSystem/IncomeTaxDeductionStrategyTest.cs
+++ b/TestPayrollSystem/IncomeTaxDeductionStrategyTest.cs
@@ -1,0 +1,26 @@
+﻿using backend.Domain.Strategies;
+using NUnit.Framework;
+
+namespace TestPayrollSystem
+{
+    [TestFixture]
+    public class IncomeTaxDeductionStrategyTest
+    {
+        private IncomeTaxDeductionStrategy _strategy;
+
+        [SetUp]
+        public void Setup()
+        {
+            _strategy = new IncomeTaxDeductionStrategy();
+        }
+
+        [Test]
+        public void CalculateDeduction_Between922kAnd1352k_Applies10Percent()
+        {
+            var salary = 1_000_000m;
+            var expected = (salary - 922_000m) * 0.10m;
+            var result = _strategy.CalculateDeduction(salary, "Permanent", "F");
+            Assert.AreEqual(Math.Round(expected, 2), result);
+        }
+    }
+}


### PR DESCRIPTION
# Description
Added unit tests for deduction calculation logic.

# Main Changes
- Implemented tests for `CcssDeductionStrategyTest`


# Motivation and Context
This improves test coverage and ensures the deduction logic behaves correctly under different conditions. It helps prevent regressions as the logic evolves.

# How to Test
1. Checkout this branch
2. Run `dotnet test` (or use the Test Explorer in Visual Studio)
3. Verify all tests in `CcssDeductionStrategyTest.cs` pass successfully

