### PR TITLE
fix(Benefit List- Main Menu): now payroll manager can edit benefits

### DIFF
--- a/frontend/src/views/BenefitList.vue
+++ b/frontend/src/views/BenefitList.vue
@@ -20,11 +20,11 @@
                   <option v-for="n in 5" :key="n" :value="n">{{ n }}</option>
               </select>
           </div>
-          <div class="col text-end">
-              <router-link to="/benefit/create" class="btn btn-dark">
-                  + Nuevo beneficio
-              </router-link>
-          </div>
+            <div class="col text-end" v-if="role !== 'Payroll Manager'">
+                <router-link to="/benefit/create" class="btn btn-dark">
+                    + Nuevo
+                </router-link>
+            </div>
       </div>
 
       <table class="table table-bordered">
@@ -62,6 +62,8 @@ import currentUserService from "@/services/currentUserService";
 
 
 const maxBenefits = ref(3); 
+
+const role = currentUserService.getCurrentUserInformationFromLocalStorage()?.position;
 
 const getCompanyMaxBenefits = async () => {
   try {

--- a/frontend/src/views/MainMenu.vue
+++ b/frontend/src/views/MainMenu.vue
@@ -34,6 +34,14 @@
           <li v-if="showOption('viewEmployees')" class="nav-item">
             <router-link to="/employees-list" class="nav-link">Empleados</router-link>
           </li>
+          <li v-if="showOption('viewBenefitsPayrollM')" class="nav-item">
+            <router-link
+              to="/benefits"
+              class="nav-link"
+            >
+              Editar Beneficios
+            </router-link>
+          </li>
           <li v-if="showOption('viewBenefits')" class="nav-item">
             <router-link
               v-if="employeeType === 'Employer'"
@@ -99,7 +107,7 @@ export default {
           "viewProfile", 
           "viewPayments", 
           "viewWorkedHours", 
-          "viewBenefits"
+          "viewBenefits",
         ],
         Employer: [
           "viewProfile",
@@ -129,6 +137,7 @@ export default {
           "viewBenefits",
           "viewGeneratePayroll",
           "viewPayrolls",
+          "viewBenefitsPayrollM"
         ],
       };
       return permissions[this.employeeType]?.includes(option);


### PR DESCRIPTION
# Description
Payroll Manager can edit benefits

# Main Changes
- Payroll Manager can edit benefits 
- Main menu has been updated

# Motivation and Context
To allow Payroll Manager to edit benefits

# How to Test
Provide clear instructions to test the changes locally, such as:
1. Log as a payroll manager
2. Check the edit benefits option in the menu
