### PR TITLE
Chore/disable benefit after deduction

### DIFF
--- a/backend/Application/DeductionsCalculation/DeductionCalculationOrchestrator.cs
+++ b/backend/Application/DeductionsCalculation/DeductionCalculationOrchestrator.cs
@@ -62,6 +62,6 @@ namespace backend.Application.DeductionCalculation
             }
 
             return details;
-        git stash pop        }
+        }
     }
 }

--- a/backend/Application/DeductionsCalculation/DeductionCalculationOrchestrator.cs
+++ b/backend/Application/DeductionsCalculation/DeductionCalculationOrchestrator.cs
@@ -1,6 +1,6 @@
+using backend.Application.Commands;
 using backend.Domain;
 using backend.Domain.Strategies;
-using System.Collections.Generic;
 
 namespace backend.Application.DeductionCalculation
 {
@@ -8,11 +8,13 @@ namespace backend.Application.DeductionCalculation
     {
         private readonly List<IDeductionCalculationStrategy> _strategies;
         private readonly BenefitDeductionStrategy _benefitStrategy;
+        private readonly IDisableBenefitForEmployeeCommand _disableBenefitForEmployeeCommand;
 
         public DeductionCalculationOrchestrator(
             CcssDeductionStrategy ccssStrategy,
             IncomeTaxDeductionStrategy incomeTaxStrategy,
-            BenefitDeductionStrategy benefitStrategy)
+            BenefitDeductionStrategy benefitStrategy,
+            IDisableBenefitForEmployeeCommand disableBenefitForEmployeeCommand)
         {
             _strategies = new List<IDeductionCalculationStrategy>
             {
@@ -20,17 +22,60 @@ namespace backend.Application.DeductionCalculation
                 incomeTaxStrategy
             };
             _benefitStrategy = benefitStrategy;
+            _disableBenefitForEmployeeCommand = disableBenefitForEmployeeCommand;
         }
 
-        public List<DeductionDetailModel> CalculateTotalDeductions(decimal grossSalary, string contractType, string gender, List<Benefit>? benefits, Guid paymentDetailsId)
+        public List<DeductionDetailModel> CalculateTotalDeductions(
+            decimal grossSalary,
+            string contractType,
+            string gender,
+            List<Benefit>? benefits,
+            Guid paymentDetailsId,
+            Guid? employeeId = null)
+        {
+            var details = ApplyMandatoryDeductions(grossSalary, contractType, gender, paymentDetailsId, out decimal totalAmountDeduced);
+
+            // If there is not benefits or employeeId is null, return mandatory deductions only
+            if (benefits == null || employeeId == null) return details;
+
+            // If gross salary minus total mandatory deductions is less than 0,
+            // disable all benefits for the employee and return mandatory deductions only
+            if (grossSalary - totalAmountDeduced < 0)
+            {
+                DisableAllBenefitsForEmployee(benefits, employeeId.Value);
+                return details;
+            }
+
+            ApplyVoluntaryDeductions(
+                grossSalary,
+                contractType,
+                gender,
+                benefits,
+                paymentDetailsId,
+                employeeId.Value,
+                totalAmountDeduced,
+                details
+            );
+
+            return details;
+        }
+
+        private List<DeductionDetailModel> ApplyMandatoryDeductions(
+            decimal grossSalary,
+            string contractType,
+            string gender,
+            Guid paymentDetailsId,
+            out decimal totalAmountDeduced)
         {
             var details = new List<DeductionDetailModel>();
+            totalAmountDeduced = 0m;
 
             foreach (var strategy in _strategies)
             {
                 var amount = strategy.CalculateDeduction(grossSalary, contractType, gender);
                 if (amount > 0)
                 {
+                    totalAmountDeduced += amount;
                     details.Add(new DeductionDetailModel
                     {
                         Id = Guid.NewGuid(),
@@ -39,29 +84,66 @@ namespace backend.Application.DeductionCalculation
                         PaymentDetailsId = paymentDetailsId,
                         DeductionType = "mandatory"
                     });
-            }
-            }
-
-            if (benefits != null)
-            {
-            foreach (var benefit in benefits)
-            {
-                    var amount = _benefitStrategy.CalculateDeduction(grossSalary,contractType,gender, benefit);
-                    if (amount > 0)
-                    {
-                        details.Add(new DeductionDetailModel
-                        {
-                            Id = Guid.NewGuid(),
-                            Name = benefit.Name,
-                            AmountDeduced = amount,
-                            PaymentDetailsId = paymentDetailsId,
-                            DeductionType = "voluntary"
-                        });
-                    }
                 }
             }
-
             return details;
+        }
+
+        private void DisableAllBenefitsForEmployee(List<Benefit> benefits, Guid employeeId)
+        {
+            foreach (var benefit in benefits)
+            {
+                _disableBenefitForEmployeeCommand.Execute(Guid.Parse(benefit.Id), employeeId);
+            }
+        }
+
+        private void ApplyVoluntaryDeductions(
+            decimal grossSalary,
+            string contractType,
+            string gender,
+            List<Benefit> benefits,
+            Guid paymentDetailsId,
+            Guid employeeId,
+            decimal totalAmountDeduced,
+            List<DeductionDetailModel> details)
+        {
+            var benefitAmounts = benefits
+                .Select(b => new
+                {
+                    Benefit = b,
+                    Amount = _benefitStrategy.CalculateDeduction(grossSalary, contractType, gender, b, employeeId)
+                })
+                .OrderBy(x => x.Amount)
+                .ToList();
+
+            decimal availableSalary = grossSalary - totalAmountDeduced;
+            bool disableRest = false;
+
+            foreach (var item in benefitAmounts)
+            {
+                if (disableRest)
+                {
+                    _disableBenefitForEmployeeCommand.Execute(Guid.Parse(item.Benefit.Id), employeeId);
+                    continue;
+                }
+
+                if (availableSalary - item.Amount < 0)
+                {
+                    _disableBenefitForEmployeeCommand.Execute(Guid.Parse(item.Benefit.Id), employeeId);
+                    disableRest = true;
+                    continue;
+                }
+
+                availableSalary -= item.Amount;
+                details.Add(new DeductionDetailModel
+                {
+                    Id = Guid.NewGuid(),
+                    Name = item.Benefit.Name,
+                    AmountDeduced = item.Amount,
+                    PaymentDetailsId = paymentDetailsId,
+                    DeductionType = "voluntary"
+                });
+            }
         }
     }
 }

--- a/backend/Application/DeductionsCalculation/DeductionCalculationOrchestrator.cs
+++ b/backend/Application/DeductionsCalculation/DeductionCalculationOrchestrator.cs
@@ -62,6 +62,6 @@ namespace backend.Application.DeductionCalculation
             }
 
             return details;
-        }
+        git stash pop        }
     }
 }

--- a/backend/Application/DisableBenefitForEmployeeCommand.cs
+++ b/backend/Application/DisableBenefitForEmployeeCommand.cs
@@ -1,0 +1,25 @@
+using backend.Domain;
+using backend.Infraestructure;
+
+namespace backend.Application.Commands
+{
+    public interface IDisableBenefitForEmployeeCommand
+    {
+        bool Execute(Guid benefitId, Guid employeeId);
+    }
+
+    public class DisableBenefitForEmployeeCommand : IDisableBenefitForEmployeeCommand
+    {
+        private readonly IBenefitRepository _repository;
+
+        public DisableBenefitForEmployeeCommand(IBenefitRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public bool Execute(Guid benefitId, Guid employeeId)
+        {
+            return _repository.DisableBenefitForEmployee(benefitId, employeeId);
+        }
+    }
+}

--- a/backend/Application/DisableBenefitForEmployeeCommand.cs
+++ b/backend/Application/DisableBenefitForEmployeeCommand.cs
@@ -1,4 +1,3 @@
-using backend.Domain;
 using backend.Infraestructure;
 
 namespace backend.Application.Commands

--- a/backend/Infraestructure/IBenefitRepository.cs
+++ b/backend/Infraestructure/IBenefitRepository.cs
@@ -1,0 +1,13 @@
+using backend.Domain;
+
+namespace backend.Infraestructure
+{
+    public interface IBenefitRepository
+    {
+        List<Benefit> GetBenefits(string companyId);
+        bool AssignBenefitsToEmployee(Guid employeeId, List<Guid> benefitIds);
+        List<Benefit> GetAssignedBenefitsForEmployee(Guid employeeId);
+        bool CreateBenefit(Benefit benefit);
+        bool DisableBenefitForEmployee(Guid benefitId, Guid employeeId);
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -107,7 +107,7 @@ builder.Services.AddScoped<IInsertDeductionDetailsCommand, InsertDeductionDetail
 builder.Services.AddScoped<GrossPaymentCalculationOrchestrator>();
 
 builder.Services.AddScoped<ICalculateGrossPaymentQuery, CalculateGrossPaymentQuery>();
-
+builder.Services.AddScoped<IDisableBenefitForEmployeeCommand, DisableBenefitForEmployeeCommand>();
 
 var app = builder.Build();
 


### PR DESCRIPTION
# Description
Benefits are disabled if employee don't have enough salary to pay it

# Main Changes
- If employees add a benefit that surpasses their salary, benefit is removed

# Motivation and Context
This change ensures that employees cannot enroll in benefits they cannot afford based on their current salary. It prevents potential system inconsistencies and financial issues by automatically removing benefits that exceed the employee's salary.

# How to Test
1. Clone this branch
2. Run frontend and backend
3. Add benefits to make sure that they surpass employee's salary
4. In Swagger, try deductions endpoint. Benefits that exceeded salary shouldn't appear