### PR TITLE
Feature 87/frontend api services

### DIFF
--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -8,6 +8,53 @@ const API_CONFIG = {
             GET_DAYS_BY_TIMESHEET_ID: (timesheetId) => `/api/timesheet/${timesheetId}/days`,
             UPDATE_DAY: (dayId) => `/day/${dayId}`,
         },
+        EMPLOYEE: {
+            BASE: '/employee',
+            CREATE_WITH_DEPENDENCIES: '/api/Employee/CreateEmployeeWithDependencies',
+            GET_BY_COMPANY_ID: (companyId) => `/api/Employee/GetEmployeesByCompanyId?companyId=${companyId}`,
+            GET_BY_ID: (employeeId) => `/api/EmployeeGetID/GetEmployeeById/${employeeId}`,
+            UPDATE: '/api/Employee/UpdateEmployee',
+            UPDATE_AS_EMPLOYER: '/api/Employer/UpdateEmployee',
+            HAS_PAYMENTS: (employeeId) => `/api/Employer/HasPayments/${employeeId}`
+        },
+        EMPLOYER: {
+            BASE: '/employer',
+            CREATE_WITH_DEPENDENCIES: '/api/Employer/CreateEmployerWithDependencies',
+            GET_BY_ID: (employerId) => `/api/EmployerGetID/GetEmployerById/${employerId}`,
+        },
+        COMPANY: {
+            BASE: '/company',
+            CREATE_WITH_DEPENDENCIES: '/api/Company/CreateCompanyWithDependencies',
+            GET_BY_ID: (companyId) => `/api/company/GetCompanyById/${companyId}`,
+            GET_ALL: '/api/company/GetCompanies',
+            GET_PAYROLLS: (companyId) => `/api/Payroll/company/${companyId}`,
+            UPDATE: (companyId) => `/api/Company/${companyId}`,
+            DELETE: (companyId) => `/api/Company/${companyId}`
+        },
+        BENEFIT: {
+            BASE: '/benefit',
+            CREATE: '/api/benefit',
+            GET_BY_COMPANY_ID: (companyId) => `/api/benefit?companyId=${companyId}`,
+            GET_BY_ID: (benefitId, companyId) => `/api/benefit/${benefitId}?companyId=${companyId}`,
+            UPDATE: (benefitId) => `/api/benefit/${benefitId}`,
+            ASSIGN: '/api/benefit/assign',
+            GET_ASSIGNED: (employeeId) => `/api/benefit/assigned?employeeId=${employeeId}`,
+            DISABLE: '/api/benefit/disable',
+            IS_ASSIGNED: (benefitId) => `/api/benefit/benefits/${benefitId}/is-assigned`
+        },
+        PAYROLL: {
+            BASE: '/payroll',
+            GET_BY_COMPANY_ID: (companyId) => `/api/payroll/company/${companyId}`,
+            GET_SUMMARY_BY_COMPANY_ID: (companyId) => `/api/payroll/company/${companyId}/summary`,
+            CREATE: '/api/payroll',
+            UPDATE: (payrollId) => `/api/payroll/${payrollId}`
+        },
+        API: {
+            BASE: '/api',
+            GET_ALL: '/api/API',
+            GET_PARAMETERS: (apiId) => `/api/API/${apiId}/parameters`,
+            SAVE_PARAMETER_VALUES: '/api/api/parameters/values'
+        },
         APPROVAL: {
             BASE: '/approval',
             GET_PENDING_BY_EMPLOYEE: '/api/approval/pending-by-employee',
@@ -17,7 +64,8 @@ const API_CONFIG = {
         },
         USER: {
             BASE: '/user',
-            GET_BY_EMAIL: '/api/User/GetUserInformationByEmail'
+            GET_BY_EMAIL: '/api/User/GetUserByEmail',
+            GET_BY_EMAIL_DETAILED: '/api/User/GetUserInformationByEmail'
         }
     }
 };

--- a/frontend/src/services/approvalService.js
+++ b/frontend/src/services/approvalService.js
@@ -1,25 +1,21 @@
 import axios from 'axios';
 import API_CONFIG from '@/config/api';
+import { handleApiError, buildApiUrl } from '@/utils/apiUtils';
 
 class ApprovalService {
-    constructor() {
-        this.apiBaseUrl = API_CONFIG.BASE_URL;
-    }
-
     async getPendingApprovalsByEmployee() {
         try {
             const endpoint = API_CONFIG.ENDPOINTS.APPROVAL.GET_PENDING_BY_EMPLOYEE;
-            const response = await axios.get(`${this.apiBaseUrl}${endpoint}`);
+            const response = await axios.get(buildApiUrl(endpoint));
             return response.data;
         } catch (error) {
             console.error('Error fetching pending approvals:', error);
-            throw this.handleApiError(error, 'Error al obtener las aprobaciones pendientes');
+            throw handleApiError(error, 'Error al obtener las aprobaciones pendientes');
         }
     }
 
     async getPendingApprovalsByEmployeeWithInfo() {
         try {
-            // Get companyId from localStorage
             const currentUserInformation = JSON.parse(localStorage.getItem('currentUserInformation'));
             const companyId = currentUserInformation?.companyId;
 
@@ -28,13 +24,13 @@ class ApprovalService {
             }
 
             const endpoint = API_CONFIG.ENDPOINTS.APPROVAL.GET_PENDING_BY_EMPLOYEE_WITH_INFO;
-            const response = await axios.get(`${this.apiBaseUrl}${endpoint}`, {
+            const response = await axios.get(buildApiUrl(endpoint), {
                 params: { companyId }
             });
             return response.data;
         } catch (error) {
             console.error('Error fetching pending approvals with info:', error);
-            throw this.handleApiError(error, 'Error al obtener las aprobaciones pendientes con información del empleado');
+            throw handleApiError(error, 'Error al obtener las aprobaciones pendientes con información del empleado');
         }
     }
 
@@ -45,11 +41,11 @@ class ApprovalService {
             }
 
             const endpoint = API_CONFIG.ENDPOINTS.APPROVAL.GET_PENDING_DAYS_BY_EMPLOYEE(employeeId);
-            const response = await axios.get(`${this.apiBaseUrl}${endpoint}`);
+            const response = await axios.get(buildApiUrl(endpoint));
             return response.data;
         } catch (error) {
             console.error('Error fetching pending days for employee:', error);
-            throw this.handleApiError(error, 'Error al obtener los días pendientes del empleado');
+            throw handleApiError(error, 'Error al obtener los días pendientes del empleado');
         }
     }
 
@@ -64,42 +60,15 @@ class ApprovalService {
             }
 
             const endpoint = API_CONFIG.ENDPOINTS.APPROVAL.APPROVE_DAY(dayId);
-            const response = await axios.post(`${this.apiBaseUrl}${endpoint}`, null, {
+            const response = await axios.post(buildApiUrl(endpoint), null, {
                 params: { supervisorId }
             });
             return response.data;
         } catch (error) {
             console.error('Error approving day:', error);
-            throw this.handleApiError(error, 'Error al aprobar el día');
+            throw handleApiError(error, 'Error al aprobar el día');
         }
-    }
-
-    handleApiError(error, defaultMessage) {
-        const apiError = new Error(defaultMessage);
-
-        if (error.response) {
-            // Server error with response
-            apiError.message = error.response.data?.message || defaultMessage;
-            apiError.status = error.response.status;
-
-            // Handle specific status codes
-            if (error.response.status === 400) {
-                apiError.message = error.response.data?.message || 'Solicitud inválida';
-            } else if (error.response.status === 404) {
-                apiError.message = 'Recurso no encontrado';
-            } else if (error.response.status === 500) {
-                apiError.message = 'Error interno del servidor';
-            }
-        } else if (error.request) {
-            // Network error
-            apiError.message = 'Error de conexión. Por favor, verifica tu conexión a internet.';
-        } else {
-            // Configuration error
-            apiError.message = 'Error interno. Por favor, intenta de nuevo.';
-        }
-
-        return apiError;
     }
 }
 
-export default new ApprovalService(); 
+export default new ApprovalService();

--- a/frontend/src/services/benefitService.js
+++ b/frontend/src/services/benefitService.js
@@ -1,0 +1,129 @@
+import axios from 'axios';
+import API_CONFIG from '@/config/api';
+import currentUserService from '@/services/currentUserService';
+import { handleApiError, buildApiUrl } from '@/utils/apiUtils';
+
+class BenefitService {
+    async createBenefit(benefitData) {
+        try {
+            const endpoint = API_CONFIG.ENDPOINTS.BENEFIT.CREATE;
+            const userInfo = currentUserService.getCurrentUserInformationFromLocalStorage();
+
+            const formattedData = {
+                ...benefitData,
+                companyId: userInfo.companyId
+            };
+
+            const response = await axios.post(buildApiUrl(endpoint), formattedData);
+            return response.data;
+        } catch (error) {
+            console.error('Error creating benefit:', error);
+            throw handleApiError(error, 'Error al crear el beneficio');
+        }
+    }
+
+    async getBenefitsByCompanyId(companyId) {
+        try {
+            const endpoint = API_CONFIG.ENDPOINTS.BENEFIT.GET_BY_COMPANY_ID(companyId);
+            const response = await axios.get(buildApiUrl(endpoint));
+            return response.data;
+        } catch (error) {
+            console.error('Error fetching benefits:', error);
+            throw handleApiError(error, 'Error al obtener los beneficios');
+        }
+    }
+
+    async getBenefitById(benefitId, companyId) {
+        try {
+            const endpoint = API_CONFIG.ENDPOINTS.BENEFIT.GET_BY_ID(benefitId, companyId);
+            const response = await axios.get(buildApiUrl(endpoint));
+            return response.data;
+        } catch (error) {
+            console.error('Error fetching benefit:', error);
+            if (error.response?.status === 404) {
+                return null;
+            }
+            throw handleApiError(error, 'Error al obtener el beneficio');
+        }
+    }
+
+    async updateBenefit(benefitId, benefitData) {
+        try {
+            const endpoint = API_CONFIG.ENDPOINTS.BENEFIT.UPDATE(benefitId);
+            const response = await axios.put(buildApiUrl(endpoint), benefitData);
+            return response.data;
+        } catch (error) {
+            console.error('Error updating benefit:', error);
+            throw handleApiError(error, 'Error al actualizar el beneficio');
+        }
+    }
+
+    async benefitIsAssigned(benefitId) {
+        try {
+            const endpoint = API_CONFIG.ENDPOINTS.BENEFIT.IS_ASSIGNED(benefitId);
+            const response = await axios.get(buildApiUrl(endpoint));
+            return response.data;
+        } catch (error) {
+            console.error('Error checking if benefit is assigned:', error);
+            throw handleApiError(error, 'Error al verificar si el beneficio está asignado');
+        }
+    }
+
+    async getAssignedBenefits(employeeId) {
+        try {
+            const endpoint = API_CONFIG.ENDPOINTS.BENEFIT.GET_ASSIGNED(employeeId);
+            const response = await axios.get(buildApiUrl(endpoint));
+            return response.data;
+        } catch (error) {
+            console.error('Error fetching assigned benefits:', error);
+            throw handleApiError(error, 'Error al obtener los beneficios asignados');
+        }
+    }
+
+    async assignBenefitsToEmployee(employeeId, benefitIds) {
+        try {
+            const endpoint = API_CONFIG.ENDPOINTS.BENEFIT.ASSIGN;
+            const payload = { employeeId, benefitIds };
+            const response = await axios.post(buildApiUrl(endpoint), payload);
+            return response.data;
+        } catch (error) {
+            console.error('Error assigning benefits:', error);
+            throw handleApiError(error, 'Error al asignar beneficios');
+        }
+    }
+
+    async getAPIs() {
+        try {
+            const endpoint = API_CONFIG.ENDPOINTS.API.GET_ALL;
+            const response = await axios.get(buildApiUrl(endpoint));
+            return response.data;
+        } catch (error) {
+            console.error('Error fetching APIs:', error);
+            throw handleApiError(error, 'Error al obtener las APIs');
+        }
+    }
+
+    async getAPIParameters(apiId) {
+        try {
+            const endpoint = API_CONFIG.ENDPOINTS.API.GET_PARAMETERS(apiId);
+            const response = await axios.get(buildApiUrl(endpoint));
+            return response.data;
+        } catch (error) {
+            console.error('Error fetching API parameters:', error);
+            throw handleApiError(error, 'Error al obtener los parámetros de la API');
+        }
+    }
+
+    async saveParameterValues(parameterData) {
+        try {
+            const endpoint = API_CONFIG.ENDPOINTS.API.SAVE_PARAMETER_VALUES;
+            const response = await axios.post(buildApiUrl(endpoint), parameterData);
+            return response.data;
+        } catch (error) {
+            console.error('Error saving parameter values:', error);
+            throw handleApiError(error, 'Error al guardar los valores de parámetros');
+        }
+    }
+}
+
+export default new BenefitService();

--- a/frontend/src/services/companyService.js
+++ b/frontend/src/services/companyService.js
@@ -1,0 +1,105 @@
+import axios from 'axios';
+import API_CONFIG from '@/config/api';
+import { handleApiError, buildApiUrl } from '@/utils/apiUtils';
+
+class CompanyService {
+    async createCompanyWithDependencies(companyData) {
+        try {
+            const endpoint = API_CONFIG.ENDPOINTS.COMPANY.CREATE_WITH_DEPENDENCIES;
+            const formattedData = this.formatCompanyDataForBackend(companyData);
+
+            const response = await axios.post(buildApiUrl(endpoint), formattedData);
+            return response.data;
+        } catch (error) {
+            console.error('Error creating company:', error);
+            throw handleApiError(error, 'Error al crear la empresa');
+        }
+    }
+
+    async getCompanyById(companyId) {
+        try {
+            const endpoint = API_CONFIG.ENDPOINTS.COMPANY.GET_BY_ID(companyId);
+            const response = await axios.get(buildApiUrl(endpoint));
+            return response.data;
+        } catch (error) {
+            console.error('Error fetching company:', error);
+            if (error.response?.status === 404) {
+                return null;
+            }
+            throw handleApiError(error, 'Error al obtener la empresa');
+        }
+    }
+
+    async getAllCompanies() {
+        try {
+            const endpoint = API_CONFIG.ENDPOINTS.COMPANY.GET_ALL;
+            const response = await axios.get(buildApiUrl(endpoint));
+            return response.data;
+        } catch (error) {
+            console.error('Error fetching companies:', error);
+            throw handleApiError(error, 'Error al obtener las empresas');
+        }
+    }
+
+    async updateCompany(companyId, companyData) {
+        try {
+            const endpoint = API_CONFIG.ENDPOINTS.COMPANY.UPDATE(companyId);
+            const formattedData = this.formatCompanyDataForUpdate(companyData);
+            const response = await axios.put(buildApiUrl(endpoint), formattedData);
+            return response.data;
+        } catch (error) {
+            console.error('Error updating company:', error);
+            throw handleApiError(error, 'Error al actualizar la empresa');
+        }
+    }
+
+    async deleteCompany(companyId) {
+        try {
+            const endpoint = API_CONFIG.ENDPOINTS.COMPANY.DELETE(companyId);
+            const response = await axios.delete(buildApiUrl(endpoint));
+            return response.data;
+        } catch (error) {
+            console.error('Error deleting company:', error);
+            throw handleApiError(error, 'Error al eliminar la empresa');
+        }
+    }
+
+    async checkCompanyHasPayrolls(companyId) {
+        try {
+            const endpoint = API_CONFIG.ENDPOINTS.COMPANY.GET_PAYROLLS(companyId);
+            const response = await axios.get(buildApiUrl(endpoint));
+            return response.data && response.data.length > 0;
+        } catch (error) {
+            return false;
+        }
+    }
+
+    formatCompanyDataForBackend(formData) {
+        const formattedLegalId = formData.person.legalId.replace(/-/g, "");
+
+        return {
+            person: {
+                ...formData.person,
+                legalId: formattedLegalId
+            },
+            company: formData.company,
+            contact: formData.contact
+        };
+    }
+
+    formatCompanyDataForUpdate(companyData) {
+        const formatted = { ...companyData };
+
+        if (formatted.person && formatted.person.legalId) {
+            formatted.person.legalId = formatted.person.legalId.replace(/-/g, '');
+        }
+
+        if (formatted.contact && formatted.contact.phoneNumber) {
+            formatted.contact.phoneNumber = formatted.contact.phoneNumber.replace(/-/g, '');
+        }
+
+        return formatted;
+    }
+}
+
+export default new CompanyService();

--- a/frontend/src/services/currentUserService.js
+++ b/frontend/src/services/currentUserService.js
@@ -1,24 +1,9 @@
-import axios from 'axios';
+import userService from '@/services/userService';
 
 class CurrentUserService {
-    constructor() {
-        this.apiBaseUrl = 'https://localhost:5000/api'; // Base URL for the API
-    }
-
-    /**
-     * Fetches the current user information by email, calls the API endpoint,
-     * and saves the information in localStorage.
-     * @param {string} email - The email address of the user.
-     * @returns {Promise<void>}
-     */
     async fetchAndSaveCurrentUserInformationToLocalStorage(email) {
         try {
-            const response = await axios.get(`${this.apiBaseUrl}/User/GetUserInformationByEmail`, {
-                params: { email }
-            });
-
-
-            const userInformation = response.data;
+            const userInformation = await userService.getUserInformationByEmail(email);
             console.log("User info recibido:", userInformation);
 
             localStorage.setItem('currentUserInformation', JSON.stringify(userInformation));
@@ -27,18 +12,11 @@ class CurrentUserService {
         }
     }
 
-    /**
-     * Retrieves the current user information from localStorage.
-     * @returns {object|null} The user information object or null if not found.
-     */
     getCurrentUserInformationFromLocalStorage() {
         const userInformation = localStorage.getItem('currentUserInformation');
         return userInformation ? JSON.parse(userInformation) : null;
     }
 
-    /**
-     * Removes the current user information from localStorage.
-     */
     removeCurrentUserInformationFromLocalStorage() {
         localStorage.removeItem('currentUserInformation');
     }
@@ -55,5 +33,4 @@ class CurrentUserService {
     }
 }
 
-// Export a pre-instantiated object of the service
 export default new CurrentUserService();

--- a/frontend/src/services/employeeService.js
+++ b/frontend/src/services/employeeService.js
@@ -1,0 +1,116 @@
+import axios from 'axios';
+import API_CONFIG from '@/config/api';
+import currentUserService from '@/services/currentUserService';
+import { handleApiError, buildApiUrl } from '@/utils/apiUtils';
+
+class EmployeeService {
+    async createEmployeeWithDependencies(employeeData) {
+        try {
+            const endpoint = API_CONFIG.ENDPOINTS.EMPLOYEE.CREATE_WITH_DEPENDENCIES;
+
+            const formattedData = this.formatEmployeeDataForBackend(employeeData);
+
+            console.log('Creating employee with data:', formattedData);
+
+            const response = await axios.post(buildApiUrl(endpoint), formattedData);
+            return response.data;
+        } catch (error) {
+            console.error('Error creating employee:', error);
+            throw handleApiError(error, 'Error al crear el empleado');
+        }
+    }
+
+    async getEmployeesByCompanyId(companyId) {
+        try {
+            if (!companyId) {
+                throw new Error('Company ID is required');
+            }
+
+            const endpoint = API_CONFIG.ENDPOINTS.EMPLOYEE.GET_BY_COMPANY_ID(companyId);
+            const response = await axios.get(buildApiUrl(endpoint));
+            return response.data;
+        } catch (error) {
+            console.error('Error fetching employees by company:', error);
+
+            if (error.response?.status === 404) {
+                return []; // No employees found
+            }
+
+            throw handleApiError(error, 'Error al obtener los empleados de la empresa');
+        }
+    }
+
+    async getEmployeeById(employeeId) {
+        try {
+            if (!employeeId) {
+                throw new Error('Employee ID is required');
+            }
+
+            const endpoint = API_CONFIG.ENDPOINTS.EMPLOYEE.GET_BY_ID(employeeId);
+            const response = await axios.get(buildApiUrl(endpoint));
+            return response.data;
+        } catch (error) {
+            console.error('Error fetching employee by ID:', error);
+
+            if (error.response?.status === 404) {
+                return null; // Employee not found
+            }
+
+            throw handleApiError(error, 'Error al obtener la información del empleado');
+        }
+    }
+
+    async updateEmployeeAsEmployer(employeeData) {
+        try {
+            const endpoint = API_CONFIG.ENDPOINTS.EMPLOYEE.UPDATE_AS_EMPLOYER;
+            const response = await axios.patch(buildApiUrl(endpoint), employeeData);
+            return response.data;
+        } catch (error) {
+            console.error('Error updating employee:', error);
+            throw handleApiError(error, 'Error al actualizar el empleado');
+        }
+    }
+
+    async checkEmployeeHasPayments(employeeId) {
+        try {
+            if (!employeeId) {
+                throw new Error('Employee ID is required');
+            }
+
+            const endpoint = API_CONFIG.ENDPOINTS.EMPLOYEE.HAS_PAYMENTS(employeeId);
+            const response = await axios.get(buildApiUrl(endpoint));
+            return response.data.hasPayments;
+        } catch (error) {
+            console.error('Error checking employee payments:', error);
+            return false; // Assume no payments if error
+        }
+    }
+
+    formatEmployeeDataForBackend(formData) {
+        const password = `${formData.naturalPerson.firstSurname}${formData.person.legalId.slice(-3)}`;
+
+        const currentUserInformation = currentUserService.getCurrentUserInformationFromLocalStorage();
+
+        const formattedLegalId = formData.person.legalId.replace(/-/g, "");
+
+        return {
+            person: {
+                ...formData.person,
+                legalId: formattedLegalId
+            },
+            user: {
+                ...formData.user,
+                password: password
+            },
+            naturalPerson: formData.naturalPerson,
+            contact: formData.contact,
+            employee: {
+                ...formData.employee,
+                companyId: currentUserInformation.companyId
+            },
+            employeeRole: formData.employeeRole
+        };
+    }
+}
+
+export default new EmployeeService(); 

--- a/frontend/src/services/employerService.js
+++ b/frontend/src/services/employerService.js
@@ -1,0 +1,68 @@
+import axios from 'axios';
+import API_CONFIG from '@/config/api';
+import currentUserService from '@/services/currentUserService';
+import { handleApiError, buildApiUrl } from '@/utils/apiUtils';
+
+class EmployerService {
+    async createEmployerWithDependencies(employerData) {
+        try {
+            const endpoint = API_CONFIG.ENDPOINTS.EMPLOYER.CREATE_WITH_DEPENDENCIES;
+            const formattedData = this.formatEmployerDataForBackend(employerData);
+
+            const response = await axios.post(buildApiUrl(endpoint), formattedData);
+            return response.data;
+        } catch (error) {
+            console.error('Error creating employer:', error);
+            throw handleApiError(error, 'Error al crear el empleador');
+        }
+    }
+
+    async getEmployerById(employerId) {
+        try {
+            const endpoint = API_CONFIG.ENDPOINTS.EMPLOYER.GET_BY_ID(employerId);
+            const response = await axios.get(buildApiUrl(endpoint));
+            return response.data;
+        } catch (error) {
+            console.error('Error fetching employer:', error);
+            if (error.response?.status === 404) {
+                return null;
+            }
+            throw handleApiError(error, 'Error al obtener el empleador');
+        }
+    }
+
+    formatEmployerDataForBackend(formData) {
+        const formattedLegalId = formData.legalId.replace(/-/g, "");
+
+        return {
+            person: {
+                legalId: formattedLegalId,
+                type: "Natural Person",
+                province: "",
+                canton: "",
+                neighborhood: "",
+                additionalDirectionDetails: ""
+            },
+            user: {
+                email: formData.email,
+                password: formData.password,
+                isAdmin: false
+            },
+            naturalPerson: {
+                firstName: formData.name.firstName,
+                firstSurname: formData.name.firstSurname,
+                secondSurname: formData.name.secondSurname,
+                gender: formData.gender || "M"
+            },
+            contact: {
+                type: "Phone Number",
+                phoneNumber: formData.phoneNumber
+            },
+            employer: {
+                companyId: currentUserService.getCurrentUserInformationFromLocalStorage()?.companyId || ""
+            }
+        };
+    }
+}
+
+export default new EmployerService();

--- a/frontend/src/services/payrollService.js
+++ b/frontend/src/services/payrollService.js
@@ -1,0 +1,29 @@
+import axios from 'axios';
+import API_CONFIG from '@/config/api';
+import { handleApiError, buildApiUrl } from '@/utils/apiUtils';
+
+class PayrollService {
+    async getPayrollsSummaryByCompanyId(companyId) {
+        try {
+            const endpoint = API_CONFIG.ENDPOINTS.PAYROLL.GET_SUMMARY_BY_COMPANY_ID(companyId);
+            const response = await axios.get(buildApiUrl(endpoint));
+            return response.data;
+        } catch (error) {
+            console.error('Error fetching payrolls summary:', error);
+            throw handleApiError(error, 'Error al obtener el resumen de planillas');
+        }
+    }
+
+    async getPayrollsByCompanyId(companyId) {
+        try {
+            const endpoint = API_CONFIG.ENDPOINTS.PAYROLL.GET_BY_COMPANY_ID(companyId);
+            const response = await axios.get(buildApiUrl(endpoint));
+            return response.data;
+        } catch (error) {
+            console.error('Error fetching payrolls:', error);
+            throw handleApiError(error, 'Error al obtener las planillas');
+        }
+    }
+}
+
+export default new PayrollService(); 

--- a/frontend/src/services/userService.js
+++ b/frontend/src/services/userService.js
@@ -1,0 +1,65 @@
+import axios from 'axios';
+import API_CONFIG from '@/config/api';
+import currentUserService from '@/services/currentUserService';
+import { handleApiError, buildApiUrl } from '@/utils/apiUtils';
+
+class UserService {
+    async login(email, password) {
+        try {
+            const user = await this.getUserByEmail(email);
+
+            if (password !== user.password) {
+                throw new Error('Correo electrónico o contraseña incorrectos.');
+            }
+
+            await currentUserService.fetchAndSaveCurrentUserInformationToLocalStorage(email);
+            return user;
+        } catch (error) {
+            console.error('Error during login:', error);
+
+            if (error.message === 'Correo electrónico o contraseña incorrectos.') {
+                throw error;
+            }
+
+            if (error.response?.status === 404) {
+                // User not found
+                throw new Error('Correo electrónico o contraseña incorrectos.');
+            } else if (error.response?.status === 500) {
+                // Server error
+                throw new Error('Ocurrió un error en el servidor. Inténtelo más tarde.');
+            }
+
+            throw handleApiError(error, 'No se pudo conectar con el servidor.');
+        }
+    }
+
+    async getUserByEmail(email) {
+        try {
+            const endpoint = API_CONFIG.ENDPOINTS.USER.GET_BY_EMAIL;
+            const response = await axios.get(buildApiUrl(endpoint), {
+                params: { email }
+            });
+
+            return response.data;
+        } catch (error) {
+            console.error('Error fetching user by email:', error);
+            throw handleApiError(error, 'Error al obtener el usuario');
+        }
+    }
+
+    async getUserInformationByEmail(email) {
+        try {
+            const endpoint = API_CONFIG.ENDPOINTS.USER.GET_BY_EMAIL_DETAILED;
+            const response = await axios.get(buildApiUrl(endpoint), {
+                params: { email }
+            });
+
+            return response.data;
+        } catch (error) {
+            console.error('Error fetching user information by email:', error);
+            throw handleApiError(error, 'Error al obtener la información del usuario');
+        }
+    }
+}
+
+export default new UserService();

--- a/frontend/src/utils/apiUtils.js
+++ b/frontend/src/utils/apiUtils.js
@@ -1,0 +1,21 @@
+import API_CONFIG from '@/config/api';
+
+export const handleApiError = (error, defaultMessage) => {
+    const apiError = new Error(defaultMessage);
+
+    if (error.response) {
+        apiError.message = error.response.data?.message || defaultMessage;
+        apiError.status = error.response.status;
+        apiError.details = error.response.data;
+    } else if (error.request) {
+        apiError.message = 'Error de conexión. Por favor, verifica tu conexión a internet.';
+    } else {
+        apiError.message = 'Error interno. Por favor, inténtalo de nuevo.';
+    }
+
+    return apiError;
+};
+
+export const buildApiUrl = (endpoint) => {
+    return `${API_CONFIG.BASE_URL}${endpoint}`;
+};

--- a/frontend/src/views/AddEmployee.vue
+++ b/frontend/src/views/AddEmployee.vue
@@ -389,7 +389,7 @@ export default {
                     return;
                 }
                 
-                const response = await employeeService.createEmployeeWithDependencies(this.formData);
+                await employeeService.createEmployeeWithDependencies(this.formData);
                 
                 alert("Empleado agregado exitosamente");
 

--- a/frontend/src/views/AddEmployee.vue
+++ b/frontend/src/views/AddEmployee.vue
@@ -215,8 +215,7 @@
 </template>
 
 <script>
-import axios from "axios";
-import currentUserService from "@/services/currentUserService";
+import employeeService from "@/services/employeeService";
 
 export default {
     name: "AddEmployee",
@@ -383,25 +382,17 @@ export default {
             return Object.values(this.errors).some(error => error !== "");
         },
         async submitForm() {
-            this.validateAllFields();
-            if (this.hasErrors()) {
-                alert("Por favor, corrija los errores en el formulario.");
-                return;
-            }
-            this.formData.user.password = `${this.formData.naturalPerson.firstSurname}${this.formData.person.legalId.slice(-3)}`;
-            const currentUserInformation = currentUserService.getCurrentUserInformationFromLocalStorage();
-            this.formData.employee.companyId = currentUserInformation.companyId;
-            this.formData.person.legalId = this.formData.person.legalId.replace(/-/g, "");
-            try {
-                console.log(this.formData)
-                const response = await axios.post(
-                    "https://localhost:5000/api/Employee/CreateEmployeeWithDependencies",
-                    this.formData
-                );
+            try {      
+                this.validateAllFields();
+                if (this.hasErrors()) {
+                    alert("Por favor, corrija los errores en el formulario.");
+                    return;
+                }
+                
+                const response = await employeeService.createEmployeeWithDependencies(this.formData);
+                
                 alert("Empleado agregado exitosamente");
-                console.log(response.data);
 
-                // Redirect to the employee-list view
                 this.$router.push({ name: "EmployeesList" });
             } catch (error) {
                 alert("Ocurrió un error al tratar de agregar el empleado.");

--- a/frontend/src/views/BenefitCreate.vue
+++ b/frontend/src/views/BenefitCreate.vue
@@ -146,7 +146,7 @@
 
 <script setup>
 import { ref, watch } from 'vue'
-import axios from 'axios'
+import benefitService from '@/services/benefitService'
 import { useRouter } from 'vue-router'
 
 const router = useRouter()
@@ -219,24 +219,12 @@ const validateBenefit = () => {
   }
 }
 
-// Guardar beneficio
 const saveBenefit = async () => {
   validateBenefit()
   if (Object.keys(errors.value).length > 0) return
 
-  const userInfo = localStorage.getItem('currentUserInformation')
-  const companyId = userInfo ? JSON.parse(userInfo).companyId : null
-
-  if (!companyId) {
-    alert('No se encontró la empresa del usuario actual.')
-    return
-  }
-
-  benefit.value.companyId = companyId
-
   try {
-    console.log('Datos enviados al backend:', benefit.value)
-    await axios.post('https://localhost:5000/api/benefit', benefit.value)
+    await benefitService.createBenefit(benefit.value)
     alert('Beneficio guardado exitosamente')
     router.push('/benefits')
   } catch (err) {
@@ -245,13 +233,11 @@ const saveBenefit = async () => {
   }
 }
 
-// Cargar APIs
 const fetchAPIs = async () => {
   try {
-    const response = await axios.get('https://localhost:5000/api/API')
-    apis.value = response.data
+    apis.value = await benefitService.getAPIs()
   } catch (err) {
-    console.error('Error cargando APIs:', err.response?.data || err.message)
+    console.error('Error cargando APIs:', err.message)
   }
 }
 

--- a/frontend/src/views/BenefitList.vue
+++ b/frontend/src/views/BenefitList.vue
@@ -56,7 +56,8 @@
 </template>
 
 <script setup>
-import axios from "axios";
+import benefitService from "@/services/benefitService";
+import companyService from "@/services/companyService";
 import { ref, onMounted } from 'vue';
 import currentUserService from "@/services/currentUserService";
 
@@ -68,12 +69,10 @@ const role = currentUserService.getCurrentUserInformationFromLocalStorage()?.pos
 const getCompanyMaxBenefits = async () => {
   try {
     const companyId = currentUserService.getCurrentUserInformationFromLocalStorage()?.companyId;
-    console.log("Company ID obtenido:", companyId);
+    const company = await companyService.getCompanyById(companyId);
 
-    const response = await axios.get(`https://localhost:5000/api/company/GetCompanyById/${companyId}`);
-
-    if (response.data?.maxBenefitsPerEmployee !== undefined) {
-      maxBenefits.value = response.data.maxBenefitsPerEmployee;
+    if (company?.maxBenefitsPerEmployee !== undefined) {
+      maxBenefits.value = company.maxBenefitsPerEmployee;
     }
   } catch (error) {
     console.error("Error obteniendo maxBenefitsPerEmployee:", error);
@@ -84,31 +83,23 @@ const benefits = ref([]);
 
 const translateType = (type) => {
     switch (type) {
-        case 'API': return 'API';
-        case 'FixedAmount': return 'Monto fijo';
-        case 'FixedPercentage': return 'Porcentaje fijo';
-        default: return 'Desconocido';
-    }
-};
-
-const getCurrentUserInformationFromLocalStorage = () => {
-    const userInformation = localStorage.getItem('currentUserInformation');
-    return userInformation ? JSON.parse(userInformation) : null;
+            case 'API': return 'API';
+            case 'FixedAmount': return 'Monto fijo';
+            case 'FixedPercentage': return 'Porcentaje fijo';
+            default: return 'Desconocido';
+        }
 };
 
 const getBenefits = async () => {
     try {
-        console.log(getCurrentUserInformationFromLocalStorage())
-        const companyId = getCurrentUserInformationFromLocalStorage()?.companyId;
-        
+        const companyId = currentUserService.getCurrentUserInformationFromLocalStorage()?.companyId;
 
         if (!companyId) {
             console.error("No se encontró el ID de la empresa en el localStorage.");
             return;
         }
 
-        const response = await axios.get(`https://localhost:5000/api/benefit?companyId=${companyId}`);
-        benefits.value = response.data;
+        benefits.value = await benefitService.getBenefitsByCompanyId(companyId);
     } catch (error) {
         console.error("No se pudieron obtener los beneficios:", error);
     }

--- a/frontend/src/views/BenefitView.vue
+++ b/frontend/src/views/BenefitView.vue
@@ -137,7 +137,7 @@
   
   import { computed, onMounted, ref } from 'vue'
   import { useRoute } from 'vue-router'
-  import axios from 'axios'
+  import benefitService from '@/services/benefitService'
   
   const route = useRoute()
   const benefitId = route.params.id
@@ -207,8 +207,7 @@
   const handleEditClick = async () => {
     try {
       const isApiType = benefit.value.type === 'API'
-      const response = await axios.get(`https://localhost:5000/api/benefit/benefits/${benefit.value.id}/is-assigned`)
-      assigned.value = response.data
+      assigned.value = await benefitService.benefitIsAssigned(benefit.value.id)
 
       if (isApiType && assigned.value) {
         showApiEditWarning.value = true
@@ -241,16 +240,11 @@
         companyId, 
       }
 
-      const response = await axios.put(
-        `https://localhost:5000/api/benefit/${benefit.value.id}`,
-        updatedBenefit
-      )
-
-      if (response.status === 200) {
-        isEditable.value = false
-        originalBenefit.value = JSON.parse(JSON.stringify(benefit.value)) 
-        alert('Beneficio actualizado correctamente.')
-      }
+      await benefitService.updateBenefit(benefit.value.id, updatedBenefit)
+    
+      isEditable.value = false
+      originalBenefit.value = JSON.parse(JSON.stringify(benefit.value)) 
+      alert('Beneficio actualizado correctamente.')
     } catch (error) {
       if (error.response?.status === 409) {
         alert('No se puede editar el beneficio porque ya fue asignado a empleados.')
@@ -267,10 +261,7 @@
   onMounted(async () => {
     try {
       const companyId = getCurrentUserInformationFromLocalStorage()?.companyId
-      const response = await axios.get(`https://localhost:5000/api/benefit/${benefitId}`, {
-        params: { companyId }
-      })
-    const data = response.data
+      const data = await benefitService.getBenefitById(benefitId, companyId)
     data.eligibleEmployeeTypes = data.eligibleEmployeeTypes || []
     benefit.value = data
     } catch (error) {

--- a/frontend/src/views/CompanyRegistration.vue
+++ b/frontend/src/views/CompanyRegistration.vue
@@ -274,7 +274,7 @@
 </template>
 
 <script>
-import axios from 'axios';
+import companyService from '@/services/companyService';
 export default {
     name: 'CompanyRegistration',
     data() {
@@ -336,10 +336,9 @@ export default {
         },
         async registerCompany() {
             try {
-                const payload = {
+                const companyData = {
                     person: {
-                        id: "",
-                        legalId: this.removeHyphens(this.company.legalEntityId),
+                        legalId: this.company.legalEntityId,
                         type: "Legal Entity",
                         province: this.company.direction.province,
                         canton: this.company.direction.canton,
@@ -349,60 +348,28 @@ export default {
                     },
                     contacts: [
                         {
-                            id: "",
                             type: "Email",
-                            phoneNumber: "",
-                            email: this.company.contact.email,
-                            personId: ""
+                            email: this.company.contact.email
                         },
                         {
-                            id: "",
                             type: "Phone Number",
-                            phoneNumber: this.removeHyphens(this.company.contact.phoneNumber),
-                            personId: ""
+                            phoneNumber: this.company.contact.phoneNumber
                         }
                     ],
                     company: {
-                        id: "",
                         name: this.company.name,
                         description: this.company.description,
                         paymentType: this.company.paymentType === "monthly" ? "Monthly" : 
                                    this.company.paymentType === "biweekly" ? "Biweekly" : "Weekly",
-                        employees: [],
-                        maxBenefitsPerEmployee: parseInt(this.company.maxBenefits),
-                        creationDate: new Date().toISOString(),
-                        creationAuthor: "system",
-                        lastModificationDate: new Date().toISOString(),
-                        lastModificationAuthor: "system"
+                        maxBenefitsPerEmployee: parseInt(this.company.maxBenefits)
                     }
                 };
                 
-                console.log("Sending data:", JSON.stringify(payload, null, 2));
-                
-                const response = await axios.post('https://localhost:5000/api/Company/CreateCompanyWithDependencies', payload);
-
-                if (response.status == 201) {
-                    this.company.id = response.data.personId;
-                    return true;
-                } else {
-                    return false;
-                }
+                const response = await companyService.createCompanyWithDependencies(companyData);
+                this.company.id = response.personId;
+                return true;
             } catch (error) {
-                console.error("Error details:", error);
-                if (error.response) {
-                    console.error("Response data:", error.response.data);
-                    console.error("Status:", error.response.status);
-                    if (error.response.data && error.response.data.errors) {
-                        console.error("Validation errors:", error.response.data.errors);
-                    }
-                } else if (error.request) {
-                    // The request was made but no response was received
-                    console.error("No response received:", error.request);
-                } else {
-                    // Something happened in setting up the request that triggered an error
-                    console.error("Error:", error.message);
-                }
-
+                console.error("Error creating company:", error);
                 return false;
             }
         },

--- a/frontend/src/views/EmployeesList.vue
+++ b/frontend/src/views/EmployeesList.vue
@@ -55,7 +55,7 @@
 </template>
 
 <script>
-import axios from 'axios'
+import employeeService from '@/services/employeeService';
 import currentUserService from "@/services/currentUserService";
 
 export default {
@@ -72,17 +72,13 @@ export default {
         const currentUserInformation = currentUserService.getCurrentUserInformationFromLocalStorage()
         const companyId = currentUserInformation.companyId
 
-        // Guardamos el tipo de empleado (para usarlo en el template)
         if (currentUserInformation?.position) {
           this.employeeType = currentUserInformation.position.replace(/\s/g, '')
         }
 
-        const response = await axios.get('https://localhost:5000/api/Employee/GetEmployeesByCompanyId', {
-          params: { companyId: companyId }
-        })
-
-        // Traducimos posiciones a español
-        this.employees = response.data.map(employee => ({
+        const employees = await employeeService.getEmployeesByCompanyId(companyId);
+        
+        this.employees = employees.map(employee => ({
           ...employee,
           position: this.translatePosition(employee.position)
         }))

--- a/frontend/src/views/EmployerRegistration.vue
+++ b/frontend/src/views/EmployerRegistration.vue
@@ -133,7 +133,7 @@
 </template>
 
 <script>
-    import axios from 'axios';
+    import employerService from '@/services/employerService';
     export default {
         name: 'EmployerRegistration',
         props: {
@@ -202,66 +202,19 @@
 
             async registerEmployer() {
                 try {
-                    const payload = {
-                        person: {
-                            id: "",
-                            legalId: this.removeHyphens(this.employer.legalId),
-                            type: "Natural Person",
-                            province: "",
-                            canton: "",
-                            district: "",
-                            neighborhood: "",
-                            additionalDirectionDetails: ""
-                        },
-                        user: {
-                            id: "",
-                            email: this.employer.email,
-                            password: this.employer.password,
-                            isAdmin: false
-                        },
-                        naturalPerson: {
-                            id: "",
-                            firstName: this.employer.name.firstName,
-                            firstSurname: this.employer.name.firstSurname,
-                            secondSurname: this.employer.name.secondSurname,
-                            userId: ""
-                        },
-                        contact: {
-                            id: "",
-                            type: "Phone Number",
-                            phoneNumber: this.removeHyphens(this.employer.phoneNumber),
-                            email: "",
-                            personId: ""
-                        },
-                        employer: {
-                            id: "",
-                            workerId: "asdf",
-                            companyId: this.companyId
-                        }
+                    const employerData = {
+                        legalId: this.employer.legalId,
+                        email: this.employer.email,
+                        password: this.employer.password,
+                        name: this.employer.name,
+                        phoneNumber: this.employer.phoneNumber,
+                        companyId: this.companyId
                     };
                     
-                    console.log("Sending data:", JSON.stringify(payload, null, 2));
-                    
-                    const response = await axios.post('https://localhost:5000/api/Employer/CreateEmployerWithDependencies', payload);
-                    
-                    if (response.status === 201) {
-                        return true;
-                    } else {
-                        return false;
-                    }
+                    await employerService.createEmployerWithDependencies(employerData);
+                    return true;
                 } catch (error) {
-                    console.error("Error details:", error);
-                    if (error.response) {
-                        console.error("Response data:", error.response.data);
-                        console.error("Status:", error.response.status);
-                        if (error.response.data && error.response.data.errors) {
-                            console.error("Validation errors:", error.response.data.errors);
-                        }
-                    } else if (error.request) {
-                        console.error("No response received:", error.request);
-                    } else {
-                        console.error("Error:", error.message);
-                    }
+                    console.error("Error creating employer:", error);
                     return false;
                 }
             },

--- a/frontend/src/views/LoginForm.vue
+++ b/frontend/src/views/LoginForm.vue
@@ -72,8 +72,7 @@
 </template>
 
 <script>
-import axios from "axios"; // Importing Axios for making HTTP requests
-import currentUserService from "@/services/currentUserService";
+import userService from "@/services/userService";
 
 export default {
   name: "LoginForm", // Component name
@@ -85,52 +84,14 @@ export default {
     };
   },
   methods: {
-    /**
-     * Handles the login process when the form is submitted.
-     * Makes an API call to validate the user's credentials.
-     */
     async handleLogin() {
-      // Reset the error message before starting the login process
       this.errorMessage = "";
 
       try {
-        // Make a GET request to the backend to fetch user data by email
-        const response = await axios.get("https://localhost:5000/api/User/GetUserByEmail", {
-          params: { email: this.email } // Pass the email as a query parameter
-        });
-
-        // Check if the response status is 200 (OK)
-        if (response.status === 200) {
-          const user = response.data; // Extract user data from the response
-
-          // Validate the password entered by the user
-          if (this.password !== user.password) {
-            // Set an error message if the password is incorrect
-            this.errorMessage = "Correo electrónico o contraseña incorrectos.";
-            return; // Exit the function
-          }
-
-          // Use the global service instance to fetch and save user information
-          await currentUserService.fetchAndSaveCurrentUserInformationToLocalStorage(this.email);
-
-          // Uncomment the following line to enable navigation
-          this.$router.push({ name: "HomeView" });
-        }
+        await userService.login(this.email, this.password);
+        this.$router.push({ name: "HomeView" });
       } catch (error) {
-        // Handle errors that occur during the API call
-        if (error.response) {
-          // Handle specific HTTP status codes
-          if (error.response.status === 404) {
-            // User not found
-            this.errorMessage = "Correo electrónico o contraseña incorrectos.";
-          } else if (error.response.status === 500) {
-            // Server error
-            this.errorMessage = "Ocurrió un error en el servidor. Inténtelo más tarde.";
-          }
-        } else {
-          // Handle unexpected errors (e.g., network issues)
-          this.errorMessage = "No se pudo conectar con el servidor.";
-        }
+        this.errorMessage = error.message;
       }
     },
     /**

--- a/frontend/src/views/PayrollsList.vue
+++ b/frontend/src/views/PayrollsList.vue
@@ -56,7 +56,7 @@
 </template>
 
 <script>
-import axios from "axios";
+import payrollService from "@/services/payrollService";
 import currentUserService from "@/services/currentUserService";
 import GeneratePayrollModal from "@/components/GeneratePayrollModal.vue";
 
@@ -81,16 +81,15 @@ export default {
           this.payrolls = [];
           return;
         }
-        const response = await axios.get(`https://localhost:5000/api/payroll/company/${companyId}/summary`);
-        this.payrolls = response.data;
+        this.payrolls = await payrollService.getPayrollsSummaryByCompanyId(companyId);
       } catch (error) {
         this.payrolls = [];
       }
     },
     formatDate(dateStr) {
       if (!dateStr) return '';
-      const date = new Date(dateStr);
-      return date.toLocaleDateString('es-CR');
+        const date = new Date(dateStr);
+        return date.toLocaleDateString('es-CR');
     },
     formatCurrency(amount) {
       if (amount == null) return '';

--- a/frontend/src/views/ViewCompaniesList.vue
+++ b/frontend/src/views/ViewCompaniesList.vue
@@ -45,7 +45,7 @@
 </template>
 
 <script>
-import axios from 'axios';
+import companyService from '@/services/companyService';
 import { ref, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
 
@@ -57,8 +57,7 @@ export default {
 
     const getCompanies = async () => {
       try {
-        const response = await axios.get('https://localhost:5000/api/Company/GetCompanies');
-        companies.value = response.data;
+        companies.value = await companyService.getAllCompanies();
       } catch (error) {
         console.error("Error fetching companies:", error);
       }

--- a/frontend/src/views/ViewCompanyInfo.vue
+++ b/frontend/src/views/ViewCompanyInfo.vue
@@ -124,7 +124,7 @@
 </template>
 
 <script>
-import axios from 'axios';
+import companyService from '@/services/companyService';
 import currentUserService from "@/services/currentUserService";
 
 export default {
@@ -160,28 +160,20 @@ export default {
   methods: {
     async getCompanyById(companyId) {
       try {
- 
-        const companyResponse = await axios.get(`https://localhost:5000/api/Company/GetCompanyById/${companyId}`);
-        this.company = companyResponse.data;
-        this.company.employeesCount = companyResponse.data.employeesDynamic.length;
+        const companyData = await companyService.getCompanyById(companyId);
+        this.company = companyData;
+        this.company.employeesCount = companyData.employeesDynamic.length;
         
-        const contactsList = companyResponse.data.contact; 
+        const contactsList = companyData.contact; 
 
         this.company.contact = {
           phoneNumber: contactsList.find(c => c.phoneNumber)?.phoneNumber || "",
           email: contactsList.find(c => c.email)?.email || ""
         };
 
-        this.company.maxBenefits = companyResponse.data.maxBenefitsPerEmployee;
+        this.company.maxBenefits = companyData.maxBenefitsPerEmployee;
 
-        try {
-          // verifica si la empresa tiene planilla
-          const payrollResponse = await axios.get(`https://localhost:5000/api/Payroll/company/${companyId}`);
-          this.hasPayroll = payrollResponse.data && payrollResponse.data.length > 0;
-        } catch (payrollError) {
-       
-          this.hasPayroll = false;
-        }
+        this.hasPayroll = await companyService.checkCompanyHasPayrolls(companyId);
       } catch (error) {
         console.error("Error retrieving company:", error);
       }
@@ -198,7 +190,7 @@ export default {
       this.isEditing = !this.isEditing;
     }, 
 
-   updateCompany() {
+   async updateCompany() {
  
       if (this.isEditingEmail && !this.emailHasValidFormat()) {
         alert("El correo no tiene un formato válido.");
@@ -216,30 +208,26 @@ export default {
         return;
       }
 
-      const currentUserInformation = currentUserService.getCurrentUserInformationFromLocalStorage();
+      try {
+        const currentUserInformation = currentUserService.getCurrentUserInformationFromLocalStorage();
 
-      const companyId = currentUserInformation.position?.trim() === "SoftwareManager"
-        ? localStorage.getItem("selectedCompanyId")
-        : currentUserInformation.companyId;
+        const companyId = currentUserInformation.position?.trim() === "SoftwareManager"
+          ? localStorage.getItem("selectedCompanyId")
+          : currentUserInformation.companyId;
 
-      this.company.id = companyId;
-      this.company.person.legalId = this.company.person.legalId.replace(/-/g, '');
-      this.company.contact.phoneNumber = this.company.contact.phoneNumber.replace(/-/g, '');
-      axios.put(`https://localhost:5000/api/Company/${companyId}`, this.company)
-        .then(() => {
-          alert("Company updated successfully");
-        })
-        .catch((error) => {
-          if (error.response && error.response.status === 409) {
-            alert(error.response.data.message || "There's a register with this data already.");
-          } else {
-            alert("An error occurred while updating the company.");
-          }
-          console.error("Data sent:", this.company);
-          console.error("Error while updating company", error.response?.data);
-        });
+        this.company.id = companyId;
+
+        await companyService.updateCompany(companyId, this.company);
+        alert("Company updated successfully");
+      } catch (error) {
+        if (error.status === 409) {
+          alert("There's a register with this data already.");
+        } else {
+          alert("An error occurred while updating the company.");
+        }
+        console.error("Error while updating company", error);
+      }
     },
-
 
     handleBack() {
       const raw = localStorage.getItem("currentUserInformation");

--- a/frontend/src/views/ViewEmployeeProfile.vue
+++ b/frontend/src/views/ViewEmployeeProfile.vue
@@ -84,10 +84,10 @@
 </template>
 
 <script>
-import axios from 'axios';
+import employeeService from '@/services/employeeService';
+import employerService from '@/services/employerService';
 import { ref, onMounted } from 'vue';
 import { computed } from 'vue';
-//import { useRoute } from 'vue-router';
 import currentUserService from "@/services/currentUserService";
 
 export default {
@@ -112,27 +112,27 @@ export default {
 
         const currentUserInformation = currentUserService.getCurrentUserInformationFromLocalStorage();
         userPosition.value = currentUserInformation.position;
-        let response;
+        let data;
 
         if (currentUserInformation.position == 'Employer') {
-          response = await axios.get(`https://localhost:5000/api/EmployerGetID/GetEmployerById/${currentUserInformation.idNaturalPerson}`);
+          data = await employerService.getEmployerById(currentUserInformation.idNaturalPerson);
         } else {
-          response = await axios.get(`https://localhost:5000/api/EmployeeGetID/GetEmployeeById/${currentUserInformation.idNaturalPerson}`);
+          data = await employeeService.getEmployeeById(currentUserInformation.idNaturalPerson);
         }
 
         employee.value = {
-          id: response.data.id || '',
-          firstName: response.data.firstName || '',
-          firstLastName: response.data.firstSurname || '',
-          secondLastName: response.data.secondSurname || '',
-          identityCard: response.data.cedula || '',
-          workerId: response.data.workerId || '',
+          id: data.id || '',
+          firstName: data.firstName || '',
+          firstLastName: data.firstSurname || '',
+          secondLastName: data.secondSurname || '',
+          identityCard: data.cedula || '',
+          workerId: data.workerId || '',
           role: currentUserInformation.position,
-          contractType: response.data.contractType || '',
-          grossSalary: response.data.grossSalary || 0,
-          email: response.data.email || '',
-          phone: response.data.phoneNumber || '',
-          gender: response.data.gender || ''
+          contractType: data.contractType || '',
+          grossSalary: data.grossSalary || 0,
+          email: data.email || '',
+          phone: data.phoneNumber || '',
+          gender: data.gender || ''
         };
 
       } catch (err) {

--- a/frontend/src/views/ViewEmployeeProfileEmployer.vue
+++ b/frontend/src/views/ViewEmployeeProfileEmployer.vue
@@ -149,10 +149,10 @@
 
 
 <script>
-import axios from 'axios';
 import { ref, onMounted, computed } from 'vue';
 import { useRoute } from 'vue-router';
 import { Modal } from 'bootstrap';
+import employeeService from '@/services/employeeService';
 
 export default {
   name: 'ViewEmployeeProfile',
@@ -237,25 +237,23 @@ const filteredLeftFields = computed(() =>
     const getEmployee = async () => {
       try {
         const id = route.params.id;
-        const response = await axios.get(`https://localhost:5000/api/EmployeeGetID/GetEmployeeById/${id}`);
-        console.log("Datos del empleado:", response.data);
+        const data = await employeeService.getEmployeeById(id);
         employee.value = {
-          id: response.data.id,
-          firstName: response.data.firstName,
-          firstSurname: response.data.firstSurname,
-          secondSurname: response.data.secondSurname,
-          gender: response.data.gender,
-          legalId: response.data.cedula,
-          workerId: response.data.workerId,
-          role: response.data.role,
-          contractType: response.data.contractType,
-          grossSalary: response.data.grossSalary,
-          email: response.data.email,
-          phoneNumber: response.data.phoneNumber
+          id: data.id,
+          firstName: data.firstName,
+          firstSurname: data.firstSurname,
+          secondSurname: data.secondSurname,
+          gender: data.gender,
+          legalId: data.cedula,
+          workerId: data.workerId,
+          role: data.role,
+          contractType: data.contractType,
+          grossSalary: data.grossSalary,
+          email: data.email,
+          phoneNumber: data.phoneNumber
         };
         Object.keys(employee.value).forEach(validateField);
-        const paymentCheck = await axios.get(`https://localhost:5000/api/Employer/HasPayments/${employee.value.id}`);
-    hasPayments.value = paymentCheck.data.hasPayments;
+        hasPayments.value = await employeeService.checkEmployeeHasPayments(employee.value.id);
       } catch (err) {
         error.value = "Error loading employee data.";
       } finally {
@@ -289,7 +287,7 @@ const filteredLeftFields = computed(() =>
           Email: employee.value.email,
           PhoneNumber: employee.value.phoneNumber
         };
-        await axios.patch('https://localhost:5000/api/Employer/UpdateEmployee', payload);
+        await employeeService.updateEmployeeAsEmployer(payload);
         editMode.value = false;
         await getEmployee();
       } catch (err) {


### PR DESCRIPTION
# Description
Implemented a complete, typed API service layer for the Vue front-end so the application can communicate with the new back-end REST endpoints.

# Main Changes
- Added `src/config/api.js` to centralise base-URL and axios configuration.
- Created 8 service modules in `src/services/`
   - `approvalService.js`
   - `benefitService.js`
   - `companyService.js`
   - `currentUserService.js`
   - `employeeService.js`
   - `employerService.js`
   - `payrollService.js`
   - `timesheetService.js`
- Added shared helper `utils/apiUtils.js` for error handling and endpoint URL building.
- Updated views to consume the new services instead of hard-coded axios calls.

# Motivation and Context
Until now the frontend called the backend directly from each view. Centralizing the API URL was necessary for deployment.

# How to Test
1. Clone this branch:  
2. Start the frontend
3. Run the backend locally on the URL configured in `src/config/api.js`.
4. Walk through the following user flows:  
   - Create a company and an employer
   - Add an employee to the company
   - Create a benefit
   - View the company, employee and benefit lists.
   - Execute the calculation of a payroll
   - Log as an employee
   - Pick an API benefit and fill out the necessary paramaters

# Related User Story
- Related to SCRUM-87 
- [User Story](https://ucr-team-p4a2f12e.atlassian.net/browse/SCRUM-87?atlOrigin=eyJpIjoiNzllYmZjNTc3NmUyNDIxMTg1YWI1N2QwY2Q0ZjUxYmUiLCJwIjoiaiJ9)